### PR TITLE
Prevent pbcopy's newline character

### DIFF
--- a/screenshot-mac
+++ b/screenshot-mac
@@ -46,6 +46,6 @@ headers = { 'X-Username': user, 'X-Signature': hash.hexdigest(), 'Content-Type':
 url = urllib2.urlopen(urllib2.Request(postURL, data, headers)).read();
 os.remove(path)
 
-os.system('echo "' + url + '" | pbcopy')
+os.system('echo "' + url + '\c" | pbcopy')
 
 os.system('/usr/local/bin/growlnotify -m "Copied URL to clipboard: '+url+'" -n "GtkGrab"')


### PR DESCRIPTION
When you paste the URL that was pushed to the pasteboard using pbcopy, you get a newline. This patch stops it.
