### PR TITLE
Use `-f` option in scrot command to avoid line artifacts left on screen

### DIFF
--- a/config.cfg-sample-linux
+++ b/config.cfg-sample-linux
@@ -2,7 +2,7 @@
 username=myuser
 password=mypass
 posturl=http://yourhost.tld/gtkgrab/handler.php
-command=scrot --b -s %s
+command=sleep 0.5 && scrot -f --b -s %s
 gifCommand=record-gif.sh $(zenity --entry --text="How long to record?") %s
 notifyCommand=notify-send --hint=int:transient:1 "Screenshot Uploaded" "Copied URL to clipboard:\n %s"
 capPath=/tmp/ss.png


### PR DESCRIPTION
Details on the issue can be read on:

resurrecting-open-source-projects/scrot#36

The `-f` option "freezes" the screen (so no redraws happen) which means refreshes aren't happening, so the lines don't get drawn on the captured screenshot. The downside is, the screen doesn't redraw, so perhaps a matter of preference here!